### PR TITLE
Pagination

### DIFF
--- a/site/layouts/partials/pagination.html
+++ b/site/layouts/partials/pagination.html
@@ -1,0 +1,27 @@
+{{ $pag := $.Paginator }}
+{{ $.Scratch.Add "i" 0 }}
+<ul class="pagination">
+  {{ with $pag.First }}
+  <li>
+    <a href="{{ .URL }}" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
+  </li>
+  {{ end }}
+  <li {{ if not $pag.HasPrev }}class="disabled"{{ end }}>
+    <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL }}{{ end }}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+  </li>
+  {{ range $pag.Pagers }}
+    {{ $.Scratch.Add "i" 1 }}
+    {{ $proximity := sub ($.Scratch.Get "i") $pag.PageNumber }}
+    {{ if and (lt $proximity 4) (gt $proximity -4) }}
+    <li {{ if eq . $pag }}class="active"{{ end }}><a href="{{ .URL }}">{{ .PageNumber }}</a></li>
+    {{ end }}
+  {{ end }}
+  <li {{ if not $pag.HasNext }}class="disabled"{{ end }}>
+    <a href="{{ if $pag.HasNext }}{{ $pag.Next.URL }}{{ end }}" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+  </li>
+  {{ with $pag.Last }}
+  <li>
+    <a href="{{ .URL }}" aria-label="Last"><span aria-hidden="true">&raquo;&raquo;</span></a>
+  </li>
+  {{ end }}
+</ul>

--- a/site/layouts/section/article.ace
+++ b/site/layouts/section/article.ace
@@ -7,4 +7,4 @@
     {{ .Render "teaser" }}
   {{ end }}
 
-  {{ template "_internal/pagination.html" . }}
+  {{ partial "pagination.html" . }}

--- a/site/layouts/section/news.ace
+++ b/site/layouts/section/news.ace
@@ -7,4 +7,4 @@
     {{ .Render "teaser" }}
   {{ end }}
 
-  {{ template "_internal/pagination.html" . }}
+  {{ partial "pagination.html" . }}

--- a/site/layouts/section/wildlife.ace
+++ b/site/layouts/section/wildlife.ace
@@ -9,4 +9,4 @@
     {{ .Render "teaser" }}
   {{ end }}
 
-  {{ template "_internal/pagination.html" . }}
+  {{ partial "pagination.html" . }}

--- a/site/layouts/taxonomy/tag.ace
+++ b/site/layouts/taxonomy/tag.ace
@@ -6,4 +6,4 @@
   {{ range  $paginator.Pages }}
     {{ .Render "teaser" }}
   {{ end }}
-  {{ template "_internal/pagination.html" . }}
+  {{ partial "pagination.html" . }}


### PR DESCRIPTION
Addresses #33 

![screen shot 2016-08-16 at 12 29 18 pm](https://cloud.githubusercontent.com/assets/3673374/17707164/173e5e3a-63ad-11e6-8ff6-7fcb4fb3e8c4.png)

In addition to the "first", "previous", "next", and "last" links we'll only show individual links within 3 pages of the currently active pagination page.